### PR TITLE
Add basic compression support

### DIFF
--- a/Converter/Sequence_Converter.py
+++ b/Converter/Sequence_Converter.py
@@ -29,6 +29,7 @@ class SequenceConverterSettings:
     decimatePercentage = 0
     saveNormals = False
     generateNormals = False
+    skipAlphaChannel = False
     mergePoints = False
     mergeDistance = 0
 
@@ -307,8 +308,9 @@ class SequenceConverter:
                 header += "property uchar red" + "\n"
                 header += "property uchar green" + "\n"
                 header += "property uchar blue" + "\n"
-                header += "property uchar alpha" + "\n"
-            
+                if(not self.convertSettings.skipAlphaChannel):
+                    header += "property uchar alpha" + "\n"
+
             else:
                 if(self.convertSettings.hasUVs == True):
                     header += "property float s" + "\n" 
@@ -347,8 +349,11 @@ class SequenceConverter:
                 #Reshape arrays into 2D array, so that the elements of one vertex each occupy one row
                 verticeColorsBytes = np.reshape(verticeColorsBytes, (-1, 4))
 
-                #Convert colors from BGRA to RGBA
-                verticeColorsBytes = verticeColorsBytes[..., [2,1,0,3]]
+                #Convert colors from BGRA to RGBA (or to RGB if alpha channel is skipped)
+                if(self.convertSettings.skipAlphaChannel):
+                    verticeColorsBytes = verticeColorsBytes[..., [2,1,0]]
+                else:
+                    verticeColorsBytes = verticeColorsBytes[..., [2,1,0,3]]
 
                 byteCombination.append(verticeColorsBytes)
 

--- a/Converter/Sequence_Converter.py
+++ b/Converter/Sequence_Converter.py
@@ -30,6 +30,7 @@ class SequenceConverterSettings:
     saveNormals = False
     generateNormals = False
     skipAlphaChannel = False
+    useHalfPrecisionFloat = False
     mergePoints = False
     mergeDistance = 0
 
@@ -295,9 +296,14 @@ class SequenceConverter:
             header += "comment Exported for use in Unity Geometry Streaming Plugin" + "\n"
 
             header += "element vertex " + str(vertexCount) + "\n"
-            header += "property float x" + "\n" 
-            header += "property float y" + "\n"
-            header += "property float z" + "\n"
+            if(self.convertSettings.useHalfPrecisionFloat and False):
+                header += "property half x" + "\n"
+                header += "property half y" + "\n"
+                header += "property half z" + "\n"
+            else:
+                header += "property float x" + "\n"
+                header += "property float y" + "\n"
+                header += "property float z" + "\n"
 
             if(self.convertSettings.hasNormals):
                 header += "property float nx" + "\n"
@@ -330,6 +336,15 @@ class SequenceConverter:
             #Flip vertice positions and normals to match Unity's coordinate system
             vertices[:,0] *= -1
             normals[:,0] *= -1
+
+            if(self.convertSettings.useHalfPrecisionFloat):
+                boundsCenter = bounds.center().astype(dtype=np.float32)
+                boundsSize = np.array([bounds.dim_x(), bounds.dim_y(), bounds.dim_z()]).astype(dtype=np.float32)
+                vertices = vertices - boundsCenter
+                vertices = vertices / boundsSize
+                vertices = vertices.astype(dtype=np.float16, casting='same_kind')
+                vertices = vertices.astype(dtype=np.float32, casting='same_kind')
+
 
             verticePositionsBytes = np.frombuffer(vertices.tobytes(), dtype=np.uint8)
             verticePositionsBytes = np.reshape(verticePositionsBytes, (-1, 12))

--- a/Converter/Sequence_Converter.py
+++ b/Converter/Sequence_Converter.py
@@ -122,10 +122,56 @@ class SequenceConverter:
             for model in self.convertSettings.modelPaths:
                 self.convert_model(model)            
         else:
+            if(self.convertSettings.halfPrecision): # The prepass is pretty slow, so we only do it if needed
+                self.prepass_models(self.convertSettings.modelPaths)
             # Process the first model to establish sequence attributes (Pointcloud or Mesh, has UVs? Normals?)
             self.convert_model(self.convertSettings.modelPaths[0]) 
             self.modelPool = ThreadPool(processes = threads)
             self.modelPool.map_async(self.convert_model, self.convertSettings.modelPaths)
+
+    def prepass_models(self, modelPaths):
+
+        if(self.terminateProcessing):
+            self.processFinishedCB(False, "")
+            return
+
+        ms = ml.MeshSet()
+
+        self.lockLoadMeshLock()
+
+        combinedBoundsCenter = [0,0,0]
+        combinedBoundsSize = [0,0,0]
+
+        for file in modelPaths:
+            inputFile = os.path.join(self.convertSettings.inputPath, file)
+            try:
+                ms.load_new_mesh(inputFile)
+            except:
+                self.unlockLoadMeshLock()
+                self.processFinishedCB(True, "Error opening file: " + inputFile)
+                return
+
+            if(self.terminateProcessing):
+                self.processFinishedCB(False, "")
+                self.unlockLoadMeshLock()
+                return
+
+            bounds = ms.current_mesh().bounding_box()
+            boundsCenter = bounds.center().astype(dtype=np.float32)
+            combinedBoundsCenter += boundsCenter
+            combinedBoundsSize = np.array([
+                max(bounds.dim_x(), combinedBoundsSize[0]),
+                max(bounds.dim_y(), combinedBoundsSize[1]),
+                max(bounds.dim_z(), combinedBoundsSize[2])
+            ])
+            ms.clear() # Keep memory usage at bay
+
+        combinedBoundsCenter[0] *= -1 # Flip X axis to match Unity coordinate system
+        combinedBoundsCenter /= len(modelPaths)
+
+        self.unlockLoadMeshLock()
+
+        self.convertSettings.metaData.set_metadata_maxbounds(combinedBoundsSize, combinedBoundsCenter)
 
     def convert_model(self, file):
 
@@ -343,12 +389,17 @@ class SequenceConverter:
             normals[:,0] *= -1
 
             if(self.convertSettings.halfPrecision):
-                boundsCenter = bounds.center().astype(dtype=np.float32)
-                boundsSize = np.array([bounds.dim_x(), bounds.dim_y(), bounds.dim_z()]).astype(dtype=np.float32)
+                # We already did a prepass to calculate the max bounds
+                boundsSize = self.convertSettings.metaData.boundsSize
+                boundsCenter = self.convertSettings.metaData.boundsCenter
                 vertices = vertices - boundsCenter
                 vertices = vertices / boundsSize
                 vertices = vertices.astype(dtype=np.float16, casting='same_kind')
-
+            else:
+                # We still need to calculate the max bounds
+                boundsSize = np.array([bounds.dim_x(), bounds.dim_y(), bounds.dim_z()])
+                boundsCenter = bounds.center()
+                self.convertSettings.metaData.set_metadata_maxbounds(boundsSize, boundsCenter)
 
             verticePositionsBytes = np.frombuffer(vertices.tobytes(), dtype=np.uint8)
             if(self.convertSettings.halfPrecision):
@@ -413,7 +464,7 @@ class SequenceConverter:
 
             f.write(bytes(body))
 
-        self.convertSettings.metaData.set_metadata_Model(vertexCount, indiceCount, headerSize, bounds, geoType, self.convertSettings.hasUVs, self.convertSettings.hasNormals, self.convertSettings.hasAlpha, self.convertSettings.halfPrecision, listIndex)
+        self.convertSettings.metaData.set_metadata_Model(vertexCount, indiceCount, headerSize, geoType, self.convertSettings.hasUVs, self.convertSettings.hasNormals, self.convertSettings.hasAlpha, self.convertSettings.halfPrecision, listIndex)
 
         self.processFinishedCB(False, "") 
 

--- a/Converter/Sequence_Converter.py
+++ b/Converter/Sequence_Converter.py
@@ -156,22 +156,19 @@ class SequenceConverter:
                 return
 
             bounds = ms.current_mesh().bounding_box()
-            bMin = bounds.min().astype(dtype=np.float32)
-            bMax = bounds.max().astype(dtype=np.float32)
+            bMin = bounds.min()
+            bMax = bounds.max()
             combinedBoundsMin = np.array([
                 min(combinedBoundsMin[0], bMin[0]),
                 min(combinedBoundsMin[1], bMin[1]),
                 min(combinedBoundsMin[2], bMin[2]),
             ])
-            combinedBoundsMax = np.arrap([
+            combinedBoundsMax = np.array([
                 max(combinedBoundsMax[0], bMax[0]),
                 max(combinedBoundsMax[1], bMax[1]),
                 max(combinedBoundsMax[2], bMax[2]),
             ])
             ms.clear() # Keep memory usage at bay
-
-        combinedBoundsCenter[0] *= -1 # Flip X axis to match Unity coordinate system
-        combinedBoundsCenter /= len(modelPaths)
 
         self.unlockLoadMeshLock()
 
@@ -394,16 +391,15 @@ class SequenceConverter:
 
             if(self.convertSettings.useCompression):
                 # We already did a prepass to calculate the max bounds
-                boundsSize = self.convertSettings.metaData.boundsSize
-                boundsCenter = self.convertSettings.metaData.boundsCenter
+                boundsCenter, boundsSize = self.convertSettings.metaData.get_metadata_bounds()
                 vertices = vertices - boundsCenter
                 vertices = vertices / boundsSize
                 vertices = vertices.astype(dtype=np.float16, casting='same_kind')
             else:
                 # We still need to calculate the max bounds
                 self.convertSettings.metaData.update_metadata_maxbounds(
-                    bounds.min().astype(dtype=np.float32),
-                    bounds.max().astype(dtype=np.float32)
+                    bounds.min(),
+                    bounds.max(),
                 )
 
             verticePositionsBytes = np.frombuffer(vertices.tobytes(), dtype=np.uint8)

--- a/Converter/Sequence_Converter.py
+++ b/Converter/Sequence_Converter.py
@@ -379,9 +379,14 @@ class SequenceConverter:
                 header += "property float z" + "\n"
 
             if(self.convertSettings.hasNormals):
-                header += "property float nx" + "\n"
-                header += "property float ny" + "\n"
-                header += "property float nz" + "\n"
+                if(self.convertSettings.useCompression):
+                    header += "property half nx" + "\n"
+                    header += "property half ny" + "\n"
+                    header += "property half nz" + "\n"
+                else:
+                    header += "property float nx" + "\n"
+                    header += "property float ny" + "\n"
+                    header += "property float nz" + "\n"
 
             if(self.convertSettings.isPointcloud == True):
                 header += "property uchar red" + "\n"
@@ -428,8 +433,17 @@ class SequenceConverter:
             byteCombination.append(verticePositionsBytes)
 
             if(self.convertSettings.hasNormals):
+
+                if(self.convertSettings.useCompression):
+                    #Squash normals into half precision for compression
+                    normals = normals.astype(dtype=np.float16, casting='same_kind')
+                
                 verticeNormalsBytes = np.frombuffer(normals.tobytes(), dtype=np.uint8)
-                verticeNormalsBytes = np.reshape(verticeNormalsBytes, (-1, 12))
+
+                if(self.convertSettings.useCompression):
+                    verticeNormalsBytes = np.reshape(verticeNormalsBytes, (-1, 6)) # 3 * 2 bytes per vertex
+                else:
+                    verticeNormalsBytes = np.reshape(verticeNormalsBytes, (-1, 12)) # 3 * 4 bytes per vertex
                 byteCombination.append(verticeNormalsBytes)
 
 

--- a/Converter/Sequence_Converter.py
+++ b/Converter/Sequence_Converter.py
@@ -40,17 +40,17 @@ class SequenceConverter:
     convertSettings = SequenceConverterSettings()
     terminateProcessing = False
     debugMode = False
-    
+
     modelPool = None
     texturePool = None
 
     processFinishedCB = None
-    
+
     loadMeshLock = Lock()
     activeThreads = 0
 
     #Only used for pointcloud normal estimation
-    lastAverageNormal = [0, 0, 0] 
+    lastAverageNormal = [0, 0, 0]
     firstEstimation = True
 
     def lockLoadMeshLock(self):
@@ -71,7 +71,7 @@ class SequenceConverter:
         self.convertSettings.metaData.headerSizes = [None] * modelCount
         self.convertSettings.metaData.verticeCounts = [None] * modelCount
         self.convertSettings.metaData.indiceCounts = [None] * modelCount
-    
+
         if(len(self.convertSettings.modelPaths) > 0):
             self.process_models()
         if(len(self.convertSettings.imagePaths) > 0):
@@ -119,12 +119,12 @@ class SequenceConverter:
         if self.debugMode:
             self.firstEstimation = True
             for model in self.convertSettings.modelPaths:
-                self.convert_model(model)            
+                self.convert_model(model)
         else:
             if(self.convertSettings.useCompression): # The prepass is pretty slow, so we only do it if needed
                 self.prepass_models(self.convertSettings.modelPaths)
             # Process the first model to establish sequence attributes (Pointcloud or Mesh, has UVs? Normals?)
-            self.convert_model(self.convertSettings.modelPaths[0]) 
+            self.convert_model(self.convertSettings.modelPaths[0])
             self.modelPool = ThreadPool(processes = threads)
             self.modelPool.map_async(self.convert_model, self.convertSettings.modelPaths)
 
@@ -201,7 +201,7 @@ class SequenceConverter:
         except:
             self.unlockLoadMeshLock()
             self.processFinishedCB(True, "Error opening file: " + inputfile)
-            return    
+            return
 
         if(self.terminateProcessing):
             self.processFinishedCB(False, "")
@@ -210,7 +210,7 @@ class SequenceConverter:
 
         faceCount = len(ms.current_mesh().face_matrix())
 
-        #Is the file a mesh or pointcloud?        
+        #Is the file a mesh or pointcloud?
         if(faceCount > 0):
             pointcloud = False
         else:
@@ -250,10 +250,10 @@ class SequenceConverter:
         #coordinates which are unsupported in Unity, so we convert them
         #Also we need to ensure that our mesh contains only triangles!
         if(self.convertSettings.isPointcloud == False and ms.current_mesh().has_wedge_tex_coord() == True):
-            ms.compute_texcoord_transfer_wedge_to_vertex()     
+            ms.compute_texcoord_transfer_wedge_to_vertex()
 
 
-        # We'll later flip the x-Axis. For meshes, this also requires us to flip the face orientation 
+        # We'll later flip the x-Axis. For meshes, this also requires us to flip the face orientation
         if(self.convertSettings.isPointcloud == False):
             ms.meshing_invert_face_orientation(forceflip = True)
 
@@ -278,10 +278,10 @@ class SequenceConverter:
                 # The dot product let's us know how if the average normals point in the same direction
                 # (-1 for opposite, 1 for same direction)
                 dot_product = np.dot(v1_norm, v2_norm)
-                
+
                 #Flip normals if the average normal differs too much from the last frame
                 if(dot_product < 0.5):
-                    normals = normals * -1 
+                    normals = normals * -1
                     averageNormal = np.multiply(averageNormal, -1)
 
             self.lastAverageNormal = averageNormal
@@ -301,16 +301,16 @@ class SequenceConverter:
         if(self.convertSettings.isPointcloud == True):
             vertices = ms.current_mesh().vertex_matrix().astype(np.float32)
             vertice_colors = ms.current_mesh().vertex_color_array()
-        
+
         else:
             vertices = ms.current_mesh().vertex_matrix().astype(np.float32)
             faces = ms.current_mesh().face_matrix()
 
-            if(self.convertSettings.hasUVs == True):     
+            if(self.convertSettings.hasUVs == True):
                 uvs = ms.current_mesh().vertex_tex_coord_matrix().astype(np.float32)
 
         #Check if the mesh has pre-existing normals
-        
+
         vertexCount = len(vertices)
 
         if(faces is not None):
@@ -374,7 +374,7 @@ class SequenceConverter:
 
             else:
                 if(self.convertSettings.hasUVs == True):
-                    header += "property float s" + "\n" 
+                    header += "property float s" + "\n"
                     header += "property float t" + "\n"
                 header += "element face " + str(len(faces)) + "\n"
                 header += "property list uchar uint vertex_indices" + "\n"
@@ -421,7 +421,7 @@ class SequenceConverter:
 
             #Constructing the mesh data, as binary array
             if(self.convertSettings.isPointcloud == True):
-                
+
                 verticeColorsBytes = np.frombuffer(vertice_colors.tobytes(), dtype=np.uint8)
 
                 #Reshape arrays into 2D array, so that the elements of one vertex each occupy one row
@@ -446,7 +446,7 @@ class SequenceConverter:
                 body = body.ravel()
 
             else:
-                
+
                 if(self.convertSettings.hasUVs == True):
                     uvsBytes = np.frombuffer(uvs.tobytes(), dtype=np.uint8)
                     uvsBytes = np.reshape(uvsBytes, (-1, 8))
@@ -471,7 +471,7 @@ class SequenceConverter:
 
         self.convertSettings.metaData.set_metadata_Model(vertexCount, indiceCount, headerSize, geoType, self.convertSettings.hasUVs, self.convertSettings.hasNormals, self.convertSettings.useCompression, listIndex)
 
-        self.processFinishedCB(False, "") 
+        self.processFinishedCB(False, "")
 
         if self.debugMode:
             print("Processed file: " + str(listIndex))
@@ -512,11 +512,11 @@ class SequenceConverter:
             outputfileDDS = os.path.join(self.convertSettings.outputPath, file_name + ".dds")
             cmd = self.convertSettings.resourcePath + "texconv " + "\"" + inputfile + "\"" + " -o " + "\"" + self.convertSettings.outputPath + "\"" +" -m 1 -f DXT1 -y -nologo"
             if(self.convertSettings.convertToSRGB):
-                cmd += " -srgbo" 
+                cmd += " -srgbo"
             if(subprocess.run(cmd, stdout=open(os.devnull, 'wb')).returncode != 0):
                 self.processFinishedCB(True, "Error converting DDS texture: " + inputfile)
                 return
-        
+
         if(self.convertSettings.convertToASTC):
             outputfileASCT = os.path.join(self.convertSettings.outputPath, file_name + ".astc")
             cmd = self.convertSettings.resourcePath + "astcenc -cl " + "\"" + inputfile + "\"" + " " + "\"" + outputfileASCT + "\"" + " 6x6 -medium -silent"
@@ -546,14 +546,14 @@ class SequenceConverter:
             if(dimensions[0] != self.convertSettings.textureDimensions[0] or dimensions[1] != self.convertSettings.textureDimensions[1]):
                 self.processFinishedCB(True, "All textures need to have the same resolution! Frame " + str(listIndex))
                 return
-        
+
         #print("Converted image file: " + file_name)
         #print()
         self.processFinishedCB(False, "")
 
     def get_image_dimensions(self, filePath):
 
-            pilimg = Image.open(filePath) 
+            pilimg = Image.open(filePath)
             pilimg.load()
             dimensions = [pilimg.width, pilimg.height]
             pilimg.close()
@@ -565,7 +565,7 @@ class SequenceConverter:
 
         pilimg = Image.open(filePath)
         pilimg.load()
-        
+
         if("gamma" in pilimg.info):
             gamma = pilimg.info["gamma"]
             if(gamma >= 0.45 and gamma <= 0.46):

--- a/Converter/Sequence_Converter.py
+++ b/Converter/Sequence_Converter.py
@@ -29,8 +29,8 @@ class SequenceConverterSettings:
     decimatePercentage = 0
     saveNormals = False
     generateNormals = False
-    skipAlphaChannel = False
-    useHalfPrecisionFloat = False
+    hasAlpha = True
+    halfPrecision = False
     mergePoints = False
     mergeDistance = 0
 
@@ -296,7 +296,7 @@ class SequenceConverter:
             header += "comment Exported for use in Unity Geometry Streaming Plugin" + "\n"
 
             header += "element vertex " + str(vertexCount) + "\n"
-            if(self.convertSettings.useHalfPrecisionFloat):
+            if(self.convertSettings.halfPrecision):
                 header += "property half x" + "\n"
                 header += "property half y" + "\n"
                 header += "property half z" + "\n"
@@ -314,7 +314,7 @@ class SequenceConverter:
                 header += "property uchar red" + "\n"
                 header += "property uchar green" + "\n"
                 header += "property uchar blue" + "\n"
-                if(not self.convertSettings.skipAlphaChannel):
+                if(self.convertSettings.hasAlpha):
                     header += "property uchar alpha" + "\n"
 
             else:
@@ -337,7 +337,7 @@ class SequenceConverter:
             vertices[:,0] *= -1
             normals[:,0] *= -1
 
-            if(self.convertSettings.useHalfPrecisionFloat):
+            if(self.convertSettings.halfPrecision):
                 boundsCenter = bounds.center().astype(dtype=np.float32)
                 boundsSize = np.array([bounds.dim_x(), bounds.dim_y(), bounds.dim_z()]).astype(dtype=np.float32)
                 vertices = vertices - boundsCenter
@@ -346,7 +346,7 @@ class SequenceConverter:
 
 
             verticePositionsBytes = np.frombuffer(vertices.tobytes(), dtype=np.uint8)
-            if(self.convertSettings.useHalfPrecisionFloat):
+            if(self.convertSettings.halfPrecision):
                 verticePositionsBytes = np.reshape(verticePositionsBytes, (-1, 6)) # 3 * 2 bytes per vertex
             else:
                 verticePositionsBytes = np.reshape(verticePositionsBytes, (-1, 12)) # 3 * 4 bytes per vertex
@@ -367,7 +367,7 @@ class SequenceConverter:
                 verticeColorsBytes = np.reshape(verticeColorsBytes, (-1, 4))
 
                 #Convert colors from BGRA to RGBA (or to RGB if alpha channel is skipped)
-                if(self.convertSettings.skipAlphaChannel):
+                if(not self.convertSettings.hasAlpha):
                     verticeColorsBytes = verticeColorsBytes[..., [2,1,0]]
                 else:
                     verticeColorsBytes = verticeColorsBytes[..., [2,1,0,3]]
@@ -408,7 +408,7 @@ class SequenceConverter:
 
             f.write(bytes(body))
 
-        self.convertSettings.metaData.set_metadata_Model(vertexCount, indiceCount, headerSize, bounds, geoType, self.convertSettings.hasUVs, self.convertSettings.hasNormals, listIndex)
+        self.convertSettings.metaData.set_metadata_Model(vertexCount, indiceCount, headerSize, bounds, geoType, self.convertSettings.hasUVs, self.convertSettings.hasNormals, self.convertSettings.hasAlpha, self.convertSettings.halfPrecision, listIndex)
 
         self.processFinishedCB(False, "") 
 

--- a/Converter/Sequence_Converter.py
+++ b/Converter/Sequence_Converter.py
@@ -296,7 +296,7 @@ class SequenceConverter:
             header += "comment Exported for use in Unity Geometry Streaming Plugin" + "\n"
 
             header += "element vertex " + str(vertexCount) + "\n"
-            if(self.convertSettings.useHalfPrecisionFloat and False):
+            if(self.convertSettings.useHalfPrecisionFloat):
                 header += "property half x" + "\n"
                 header += "property half y" + "\n"
                 header += "property half z" + "\n"
@@ -343,11 +343,13 @@ class SequenceConverter:
                 vertices = vertices - boundsCenter
                 vertices = vertices / boundsSize
                 vertices = vertices.astype(dtype=np.float16, casting='same_kind')
-                vertices = vertices.astype(dtype=np.float32, casting='same_kind')
 
 
             verticePositionsBytes = np.frombuffer(vertices.tobytes(), dtype=np.uint8)
-            verticePositionsBytes = np.reshape(verticePositionsBytes, (-1, 12))
+            if(self.convertSettings.useHalfPrecisionFloat):
+                verticePositionsBytes = np.reshape(verticePositionsBytes, (-1, 6)) # 3 * 2 bytes per vertex
+            else:
+                verticePositionsBytes = np.reshape(verticePositionsBytes, (-1, 12)) # 3 * 4 bytes per vertex
             byteCombination.append(verticePositionsBytes)
 
             if(self.convertSettings.hasNormals):

--- a/Converter/Sequence_Converter_UI.py
+++ b/Converter/Sequence_Converter_UI.py
@@ -27,8 +27,7 @@ class ConverterUI:
     decimation_percentage_ID = 0
     save_normals_ID = 0
     generate_normals_ID = 0
-    skip_alpha_channel_ID = 0
-    use_half_precision_float_ID = 0
+    use_compression_ID = 0
 
     ### +++++++++++++++++++++++++  PACKAGE INTO SINGLE WINDOWS EXECUTABLE ++++++++++++++++++++++++++++++++++
     #Use this prompt in the terminal to package this script into a single executable for your system
@@ -62,8 +61,7 @@ class ConverterUI:
     convertToSRGB = False
     decimatePointcloud = False
     generateNormals = False
-    hasAlpha = True
-    halfPrecision = False
+    useCompression = False
     save_normals = False
     decimatePercentage = 100
     mergePoints = False
@@ -120,13 +118,9 @@ class ConverterUI:
         dpg.set_value(self.save_normals_ID, app_data)
         self.write_settings_string("generateNormals", str(app_data))
 
-    def set_Has_Alpha_Channel_cb(self, sender, app_data):
-        self.hasAlpha = app_data
-        self.write_settings_string("hasAlpha", str(app_data))
-
-    def set_Half_Precision_Float_cb(self, sender, app_data):
-        self.halfPrecision = app_data
-        self.write_settings_string("halfPrecision", str(app_data))
+    def set_Use_Compression_cb(self, sender, app_data):
+        self.useCompression = app_data
+        self.write_settings_string("useCompression", str(app_data))
 
     def set_normals_enabled_cb(self, sender, app_data):
         self.save_normals = app_data
@@ -181,12 +175,11 @@ class ConverterUI:
         convertSettings.decimatePercentage = self.decimatePercentage
         convertSettings.saveNormals = self.save_normals
         convertSettings.generateNormals = self.generateNormals
-        convertSettings.hasAlpha = self.hasAlpha
-        convertSettings.halfPrecision = self.halfPrecision
+        convertSettings.useCompression = self.useCompression
         convertSettings.mergePoints = self.mergePoints
         convertSettings.mergeDistance = self.mergeDistance
 
-        if (self.halfPrecision):
+        if (self.useCompression):
             self.info_text_set("Preprocessing models for half-precision conversion...")
             # Preprocessing the models locks the main thread, so we need to render a frame to update the UI first
             dpg.render_dearpygui_frame()
@@ -498,8 +491,7 @@ class ConverterUI:
                     self.merge_distance_ID = dpg.add_input_float(label= " ", default_value=self.mergeDistance , callback=self.set_Merge_Distance_cb, min_value=0, width= 200)
 
                 self.generate_normals_ID = dpg.add_checkbox(label= "Estimate normals", default_value=self.generateNormals, callback=self.set_Generate_Normals_enabled_cb)
-                self.has_alpha_ID = dpg.add_checkbox(label= "Has Alpha channel", default_value=self.hasAlpha, callback=self.set_Has_Alpha_Channel_cb)
-                self.half_precision_ID = dpg.add_checkbox(label= "Use half-precision floats for coordinates", default_value=self.halfPrecision, callback=self.set_Half_Precision_Float_cb)
+                self.use_compression_ID = dpg.add_checkbox(label= "Use Compression", default_value=self.useCompression, callback=self.set_Use_Compression_cb)
 
             dpg.add_spacer(height=5)
 

--- a/Converter/Sequence_Converter_UI.py
+++ b/Converter/Sequence_Converter_UI.py
@@ -62,8 +62,8 @@ class ConverterUI:
     convertToSRGB = False
     decimatePointcloud = False
     generateNormals = False
-    skipAlphaChannel = False
-    useHalfPrecisionFloat = False
+    hasAlpha = True
+    halfPrecision = False
     save_normals = False
     decimatePercentage = 100
     mergePoints = False
@@ -120,13 +120,13 @@ class ConverterUI:
         dpg.set_value(self.save_normals_ID, app_data)
         self.write_settings_string("generateNormals", str(app_data))
 
-    def set_Skip_Alpha_Channel_cb(self, sender, app_data):
-        self.skipAlphaChannel = app_data
-        self.write_settings_string("skipAlphaChannel", str(app_data))
+    def set_Has_Alpha_Channel_cb(self, sender, app_data):
+        self.hasAlpha = app_data
+        self.write_settings_string("hasAlpha", str(app_data))
 
-    def set_Use_Half_Precision_Float_cb(self, sender, app_data):
-        self.useHalfPrecisionFloat = app_data
-        self.write_settings_string("useHalfPrecisionFloat", str(app_data))
+    def set_Half_Precision_Float_cb(self, sender, app_data):
+        self.halfPrecision = app_data
+        self.write_settings_string("halfPrecision", str(app_data))
 
     def set_normals_enabled_cb(self, sender, app_data):
         self.save_normals = app_data
@@ -181,8 +181,8 @@ class ConverterUI:
         convertSettings.decimatePercentage = self.decimatePercentage
         convertSettings.saveNormals = self.save_normals
         convertSettings.generateNormals = self.generateNormals
-        convertSettings.skipAlphaChannel = self.skipAlphaChannel
-        convertSettings.useHalfPrecisionFloat = self.useHalfPrecisionFloat
+        convertSettings.hasAlpha = self.hasAlpha
+        convertSettings.halfPrecision = self.halfPrecision
         convertSettings.mergePoints = self.mergePoints
         convertSettings.mergeDistance = self.mergeDistance
 
@@ -494,8 +494,8 @@ class ConverterUI:
                     self.merge_distance_ID = dpg.add_input_float(label= " ", default_value=self.mergeDistance , callback=self.set_Merge_Distance_cb, min_value=0, width= 200)
 
                 self.generate_normals_ID = dpg.add_checkbox(label= "Estimate normals", default_value=self.generateNormals, callback=self.set_Generate_Normals_enabled_cb)
-                self.skip_alpha_channel_ID = dpg.add_checkbox(label= "Don't export Alpha channel", default_value=self.skipAlphaChannel, callback=self.set_Skip_Alpha_Channel_cb)
-                self.use_half_precision_float_ID = dpg.add_checkbox(label= "Use half-precision floats for coordinates", default_value=self.useHalfPrecisionFloat, callback=self.set_Use_Half_Precision_Float_cb)
+                self.has_alpha_ID = dpg.add_checkbox(label= "Has Alpha channel", default_value=self.hasAlpha, callback=self.set_Has_Alpha_Channel_cb)
+                self.half_precision_ID = dpg.add_checkbox(label= "Use half-precision floats for coordinates", default_value=self.halfPrecision, callback=self.set_Half_Precision_Float_cb)
 
             dpg.add_spacer(height=5)
 

--- a/Converter/Sequence_Converter_UI.py
+++ b/Converter/Sequence_Converter_UI.py
@@ -33,7 +33,7 @@ class ConverterUI:
     #Use this prompt in the terminal to package this script into a single executable for your system
     #You need to have PyInstaller installed in your local environment
     # pyinstaller Sequence_Converter_UI.py --icon=resources/logo.ico -F
-    
+
     ### +++++++++++++++++++++++++  PACKAGE INTO SINGLE MACOS APP  ++++++++++++++++++++++++++++++++++
     # Use this prompt in the terminal to package this script into a single macOS app
     # Please note that texture conversion is not yet supported on macOS!
@@ -86,7 +86,7 @@ class ConverterUI:
             selectedDir = self.open_file_dialog(self.inputSequencePath)
         else:
             selectedDir = self.open_file_dialog(self.outputSequencePath)
-        
+
         self.set_output_files(selectedDir)
 
     def cancel_processing_cb(self):
@@ -138,7 +138,7 @@ class ConverterUI:
 
         if(self.isRunning):
             return
-        
+
         self.terminationSignal.clear()
 
         self.info_text_clear()
@@ -156,7 +156,7 @@ class ConverterUI:
             if not (os.path.exists(self.proposedOutputPath)):
                 os.mkdir(self.proposedOutputPath)
 
-        self.totalFileCount =  len(self.modelPathList) 
+        self.totalFileCount =  len(self.modelPathList)
         if(self.generateASTC or self.generateDDS):
             self.totalFileCount += len(self.imagePathList)
         self.processedFileCount = 0
@@ -197,7 +197,7 @@ class ConverterUI:
     # --- File Handeling ---
 
     def InitDefaultPaths(self):
-    
+
         # Determine on what platform we are running (macOS or Windows)
         if (sys.platform != "darwin") and (sys.platform != "win32"):
             print("Your platform is currently not supported! The Sequence Converter supports Windows and macOS (partially)")
@@ -222,9 +222,9 @@ class ConverterUI:
 
     def open_file_dialog(self, path):
         Tk().withdraw() # we don't want a full GUI, so keep the root window from appearing
-        
+
         if(path is None):
-            new_input_path = askdirectory() 
+            new_input_path = askdirectory()
         else:
             new_input_path = askdirectory(initialdir=path, )
 
@@ -249,7 +249,7 @@ class ConverterUI:
 
             self.inputPathValid = True
             self.write_path_string("input", new_input_path)
-            
+
         else:
             self.info_text_clear()
             self.error_text_set(res)
@@ -260,7 +260,7 @@ class ConverterUI:
                 return "Folder does not exist!"
 
             files = os.listdir(input_path)
-            
+
             #Sort the files into model and images
             for file in files:
                 splitted_path = file.split(".")
@@ -268,7 +268,7 @@ class ConverterUI:
 
                 if(file_ending in self.validModelTypes):
                     self.modelPathList.append(file)
-                
+
                 elif(file_ending in self.validImageTypes):
                     self.imagePathList.append(file)
 
@@ -277,7 +277,7 @@ class ConverterUI:
 
             if(len(self.modelPathList) < 1 and len(self.imagePathList) < 1):
                 return "No model/image files found in folder!"
-            
+
             if(len(self.imagePathList) > 1):
                 self.convertToSRGB = self.converter.get_image_gamme_encoded(os.path.join(input_path, self.imagePathList[0]))
                 self.set_SRGB_enabled(self.convertToSRGB)
@@ -337,13 +337,13 @@ class ConverterUI:
 
     def read_path_string(self, key):
         return self.config['Paths'][key]
-    
+
     def read_settings_string(self, key):
         return self.config['Settings'][key]
-    
+
     def read_config_bool(self, key):
         return self.config['Settings'].getboolean(key)
-    
+
     def write_path_string(self, key, value):
         self.config['Paths'][key] = value
 
@@ -398,7 +398,7 @@ class ConverterUI:
 
         self.progressbarLock.release()
 
-    def finish_conversion(self):             
+    def finish_conversion(self):
         self.converter.finish_conversion(not self.terminationSignal.is_set())
 
         if(self.terminationSignal.is_set()):
@@ -406,7 +406,7 @@ class ConverterUI:
         else:
             self.info_text_set("Finished!")
         self.set_progressbar(0)
-        
+
         self.isRunning = False
 
     def set_progressbar(self, progress):
@@ -462,12 +462,12 @@ class ConverterUI:
         dpg.configure_app(manual_callback_management=True)
         dpg.create_viewport(height=500, width=500, title="Geometry Sequence Converter")
         dpg.setup_dearpygui()
-        
+
         with dpg.window(label="Geometry Sequence Converter", tag="main_window", min_size= [500, 500]):
-            
+
             dpg.add_button(label="Select Input Directory", callback=lambda:self.open_input_dir_cb())
             self.text_input_Dir_ID = dpg.add_text(self.inputSequencePath, wrap=450)
-            
+
             dpg.add_spacer(height=40)
 
             dpg.add_button(label="Select Output Directory", callback=lambda:self.open_output_dir_cb())
@@ -477,11 +477,11 @@ class ConverterUI:
 
             dpg.add_text("General settings:")
             self.save_normals_ID = dpg.add_checkbox(label="Save normals", default_value=self.save_normals, callback=self.set_normals_enabled_cb)
-            
+
             dpg.add_spacer(height=5)
 
             with dpg.collapsing_header(label="Pointcloud settings", default_open=False) as header_pcSettings_ID:
-                
+
                 with dpg.group(horizontal=True):
                     self.pointcloud_decimation_ID = dpg.add_checkbox(label="Decimate Pointcloud", default_value=self.decimatePointcloud, callback=self.set_Decimation_enabled_cb)
                     self.decimation_percentage_ID = dpg.add_input_int(label=" %", default_value=self.decimatePercentage, min_value=0, max_value=100, width=80, callback=self.set_Decimation_percentage_cb)
@@ -498,18 +498,18 @@ class ConverterUI:
             with dpg.collapsing_header(label="Texture settings", default_open=False) as header_textureSettings_ID:
                 dpg.add_checkbox(label="Generate textures for desktop devices (DDS)", default_value=self.generateDDS, callback=self.set_DDS_enabled_cb)
                 dpg.add_checkbox(label="Generate textures mobile devices (ASTC)", default_value=self.generateASTC, callback=self.set_ASTC_enabled_cb)
-                self.srgb_check_ID = dpg.add_checkbox(label="Convert to SRGB profile", default_value=self.convertToSRGB, callback=self.set_SRGB_enabled_cb)            
+                self.srgb_check_ID = dpg.add_checkbox(label="Convert to SRGB profile", default_value=self.convertToSRGB, callback=self.set_SRGB_enabled_cb)
 
             self.text_error_log_ID = dpg.add_text("", color=[255, 0, 0], wrap=450)
             self.text_info_log_ID = dpg.add_text("", color=[255, 255, 255], wrap=450)
-            
+
             self.progress_bar_ID = dpg.add_progress_bar(default_value=0, width=470)
             dpg.add_spacer(height=5)
 
             with dpg.group(horizontal=True):
                 dpg.add_button(label="Start Conversion", callback=lambda:self.start_conversion_cb())
                 dpg.add_button(label="Cancel", callback=lambda:self.cancel_processing_cb())
-                self.thread_count_ID = dpg.add_input_int(label="Thread count", default_value=8, min_value=0, max_value=64, width=100, tag="threadCount")        
+                self.thread_count_ID = dpg.add_input_int(label="Thread count", default_value=8, min_value=0, max_value=64, width=100, tag="threadCount")
 
         dpg.show_viewport()
         dpg.set_primary_window("main_window", True)
@@ -524,11 +524,11 @@ class ConverterUI:
             dpg.render_dearpygui_frame()
             jobs = dpg.get_callback_queue()
             dpg.run_callbacks(jobs)
-            
+
             if(dpg.is_item_left_clicked(header_pcSettings_ID)):
                 pointcloud_header_open = not pointcloud_header_open
                 self.set_viewport_height(pointcloud_header_open, texture_header_open)
-            
+
             if(dpg.is_item_left_clicked(header_textureSettings_ID)):
                 texture_header_open = not texture_header_open
                 self.set_viewport_height(pointcloud_header_open, texture_header_open)
@@ -536,7 +536,7 @@ class ConverterUI:
             if(self.conversionFinished):
                 self.finish_conversion()
                 self.conversionFinished = False
-            
+
         # Shutdown threads when they are still running
         self.cancel_processing_cb()
         self.save_config()

--- a/Converter/Sequence_Converter_UI.py
+++ b/Converter/Sequence_Converter_UI.py
@@ -28,6 +28,7 @@ class ConverterUI:
     save_normals_ID = 0
     generate_normals_ID = 0
     skip_alpha_channel_ID = 0
+    use_half_precision_float_ID = 0
 
     ### +++++++++++++++++++++++++  PACKAGE INTO SINGLE WINDOWS EXECUTABLE ++++++++++++++++++++++++++++++++++
     #Use this prompt in the terminal to package this script into a single executable for your system
@@ -62,6 +63,7 @@ class ConverterUI:
     decimatePointcloud = False
     generateNormals = False
     skipAlphaChannel = False
+    useHalfPrecisionFloat = False
     save_normals = False
     decimatePercentage = 100
     mergePoints = False
@@ -122,6 +124,10 @@ class ConverterUI:
         self.skipAlphaChannel = app_data
         self.write_settings_string("skipAlphaChannel", str(app_data))
 
+    def set_Use_Half_Precision_Float_cb(self, sender, app_data):
+        self.useHalfPrecisionFloat = app_data
+        self.write_settings_string("useHalfPrecisionFloat", str(app_data))
+
     def set_normals_enabled_cb(self, sender, app_data):
         self.save_normals = app_data
         self.write_settings_string("saveNormals", str(app_data))
@@ -176,6 +182,7 @@ class ConverterUI:
         convertSettings.saveNormals = self.save_normals
         convertSettings.generateNormals = self.generateNormals
         convertSettings.skipAlphaChannel = self.skipAlphaChannel
+        convertSettings.useHalfPrecisionFloat = self.useHalfPrecisionFloat
         convertSettings.mergePoints = self.mergePoints
         convertSettings.mergeDistance = self.mergeDistance
 
@@ -488,6 +495,7 @@ class ConverterUI:
 
                 self.generate_normals_ID = dpg.add_checkbox(label= "Estimate normals", default_value=self.generateNormals, callback=self.set_Generate_Normals_enabled_cb)
                 self.skip_alpha_channel_ID = dpg.add_checkbox(label= "Don't export Alpha channel", default_value=self.skipAlphaChannel, callback=self.set_Skip_Alpha_Channel_cb)
+                self.use_half_precision_float_ID = dpg.add_checkbox(label= "Use half-precision floats for coordinates", default_value=self.useHalfPrecisionFloat, callback=self.set_Use_Half_Precision_Float_cb)
 
             dpg.add_spacer(height=5)
 

--- a/Converter/Sequence_Converter_UI.py
+++ b/Converter/Sequence_Converter_UI.py
@@ -356,6 +356,12 @@ class ConverterUI:
             self.human_sort(self.modelPathList)
             self.human_sort(self.imagePathList)
 
+            # Check if the files are already compressed
+            modelPath = os.path.join(input_path, self.modelPathList[0])
+            with open(modelPath, 'rb') as f:
+                text = f.read(200).decode('ascii', errors='ignore')
+                if("half") in text:
+                    return "Sequence is already compressed! Please use the original sequence for conversion."
             return True
 
     def set_proposed_output_files(self, input_path):

--- a/Converter/Sequence_Converter_UI.py
+++ b/Converter/Sequence_Converter_UI.py
@@ -27,6 +27,7 @@ class ConverterUI:
     decimation_percentage_ID = 0
     save_normals_ID = 0
     generate_normals_ID = 0
+    skip_alpha_channel_ID = 0
 
     ### +++++++++++++++++++++++++  PACKAGE INTO SINGLE WINDOWS EXECUTABLE ++++++++++++++++++++++++++++++++++
     #Use this prompt in the terminal to package this script into a single executable for your system
@@ -60,6 +61,7 @@ class ConverterUI:
     convertToSRGB = False
     decimatePointcloud = False
     generateNormals = False
+    skipAlphaChannel = False
     save_normals = False
     decimatePercentage = 100
     mergePoints = False
@@ -116,6 +118,10 @@ class ConverterUI:
         dpg.set_value(self.save_normals_ID, app_data)
         self.write_settings_string("generateNormals", str(app_data))
 
+    def set_Skip_Alpha_Channel_cb(self, sender, app_data):
+        self.skipAlphaChannel = app_data
+        self.write_settings_string("skipAlphaChannel", str(app_data))
+
     def set_normals_enabled_cb(self, sender, app_data):
         self.save_normals = app_data
         self.write_settings_string("saveNormals", str(app_data))
@@ -169,6 +175,7 @@ class ConverterUI:
         convertSettings.decimatePercentage = self.decimatePercentage
         convertSettings.saveNormals = self.save_normals
         convertSettings.generateNormals = self.generateNormals
+        convertSettings.skipAlphaChannel = self.skipAlphaChannel
         convertSettings.mergePoints = self.mergePoints
         convertSettings.mergeDistance = self.mergeDistance
 
@@ -480,7 +487,8 @@ class ConverterUI:
                     self.merge_distance_ID = dpg.add_input_float(label= " ", default_value=self.mergeDistance , callback=self.set_Merge_Distance_cb, min_value=0, width= 200)
 
                 self.generate_normals_ID = dpg.add_checkbox(label= "Estimate normals", default_value=self.generateNormals, callback=self.set_Generate_Normals_enabled_cb)
-            
+                self.skip_alpha_channel_ID = dpg.add_checkbox(label= "Don't export Alpha channel", default_value=self.skipAlphaChannel, callback=self.set_Skip_Alpha_Channel_cb)
+
             dpg.add_spacer(height=5)
 
             with dpg.collapsing_header(label="Texture settings", default_open=False) as header_textureSettings_ID:

--- a/Converter/Sequence_Converter_UI.py
+++ b/Converter/Sequence_Converter_UI.py
@@ -186,6 +186,10 @@ class ConverterUI:
         convertSettings.mergePoints = self.mergePoints
         convertSettings.mergeDistance = self.mergeDistance
 
+        if (self.halfPrecision):
+            self.info_text_set("Preprocessing models for half-precision conversion...")
+            # Preprocessing the models locks the main thread, so we need to render a frame to update the UI first
+            dpg.render_dearpygui_frame()
         self.converter.start_conversion(convertSettings, self.single_conversion_finished_cb)
 
         self.info_text_set("Converting...")

--- a/Converter/Sequence_Metadata.py
+++ b/Converter/Sequence_Metadata.py
@@ -36,19 +36,7 @@ class MetaData():
     metaDataLock = Lock()
 
     def get_as_dict(self):
-        boundsCenter = [
-            (self.boundsMax[0] + self.boundsMin[0]) / 2,
-            (self.boundsMax[1] + self.boundsMin[1]) / 2,
-            (self.boundsMax[2] + self.boundsMin[2]) / 2,
-        ]
-        # Flip bounds x axis, as we also flip the model's x axis to match Unity's coordinate system
-        boundsCenter[0] *= -1
-
-        boundsSize = [
-            self.boundsMax[0] - self.boundsMin[0],
-            self.boundsMax[1] - self.boundsMin[1],
-            self.boundsMax[2] - self.boundsMin[2],
-        ]
+        boundsCenter, boundsSize = self._get_metadata_bounds()
 
         asDict = {
             "geometryType" : int(self.geometryType),
@@ -118,6 +106,35 @@ class MetaData():
         ]
 
         self.metaDataLock.release()
+
+    def get_metadata_bounds(self):
+        
+        self.metaDataLock.acquire()
+
+        boundsCenter, boundsSize = self._get_metadata_bounds()
+
+        self.metaDataLock.release()
+
+        return boundsCenter, boundsSize
+    
+    def _get_metadata_bounds(self):
+
+        boundsCenter = [
+            (self.boundsMax[0] + self.boundsMin[0]) / 2,
+            (self.boundsMax[1] + self.boundsMin[1]) / 2,
+            (self.boundsMax[2] + self.boundsMin[2]) / 2,
+        ]
+        # Flip bounds x axis, as we also flip the model's x axis to match Unity's coordinate system
+        boundsCenter[0] *= -1
+
+        boundsSize = [
+            self.boundsMax[0] - self.boundsMin[0],
+            self.boundsMax[1] - self.boundsMin[1],
+            self.boundsMax[2] - self.boundsMin[2],
+        ]
+
+        return boundsCenter, boundsSize
+
 
     def set_metadata_texture(self, DDS, ASTC, width, height, sizeDDS, sizeASTC, textureMode):
 

--- a/Converter/Sequence_Metadata.py
+++ b/Converter/Sequence_Metadata.py
@@ -33,7 +33,7 @@ class MetaData():
     indiceCounts = []
 
     #Ensure that this class can be called from multiple threads
-    metaDataLock = Lock() 
+    metaDataLock = Lock()
 
     def get_as_dict(self):
         boundsCenter = [
@@ -124,7 +124,7 @@ class MetaData():
         self.metaDataLock.acquire()
 
         if(height > self.textureHeight):
-            self.textureHeight = height 
+            self.textureHeight = height
 
         if(width > self.textureWidth):
             self.textureWidth = width
@@ -148,6 +148,6 @@ class MetaData():
         outputPath = outputDir + "/sequence.json"
         content = self.get_as_dict()
         with open(outputPath, 'w') as f:
-            json.dump(content, f)    
+            json.dump(content, f)
 
         self.metaDataLock.release()

--- a/Converter/Sequence_Metadata.py
+++ b/Converter/Sequence_Metadata.py
@@ -19,6 +19,8 @@ class MetaData():
     ASTC = False
     hasUVs = False
     hasNormals = False
+    hasAlpha = True
+    halfPrecision = False
     maxVertexCount = 0
     maxIndiceCount = 0
     boundsCenter = [0,0,0]
@@ -43,6 +45,8 @@ class MetaData():
             "ASTC" : self.ASTC,
             "hasUVs" : self.hasUVs,
             "hasNormals" : self.hasNormals,
+            "hasAlpha" : self.hasAlpha,
+            "halfPrecision": self.halfPrecision,
             "maxVertexCount": self.maxVertexCount,
             "maxIndiceCount" : self.maxIndiceCount,
             "boundsCenter" : self.boundsCenter,
@@ -57,14 +61,16 @@ class MetaData():
         }
 
         return asDict
-        
-    def set_metadata_Model(self, vertexCount, indiceCount, headerSize, bounds, geometryType, hasUV, hasNormals, listIndex):
-        
+
+    def set_metadata_Model(self, vertexCount, indiceCount, headerSize, bounds, geometryType, hasUV, hasNormals, hasAlpha, halfPrecision, listIndex):
+
         self.metaDataLock.acquire()
 
         self.geometryType = geometryType
         self.hasUVs = hasUV
         self.hasNormals = hasNormals
+        self.hasAlpha = hasAlpha
+        self.halfPrecision = halfPrecision
 
         if(vertexCount > self.maxVertexCount):
             self.maxVertexCount = vertexCount

--- a/Converter/Sequence_Metadata.py
+++ b/Converter/Sequence_Metadata.py
@@ -49,8 +49,16 @@ class MetaData():
             "halfPrecision": self.halfPrecision,
             "maxVertexCount": self.maxVertexCount,
             "maxIndiceCount" : self.maxIndiceCount,
-            "boundsCenter" : self.boundsCenter,
-            "boundsSize" : self.boundsSize,
+            "boundsCenter" : { # Export bounds as dicts for easier JSON parsing to Vector3 in Unity
+                "x" : self.boundsCenter[0],
+                "y" : self.boundsCenter[1],
+                "z" : self.boundsCenter[2]
+            },
+            "boundsSize" : {
+                "x" : self.boundsSize[0],
+                "y" : self.boundsSize[1],
+                "z" : self.boundsSize[2]
+            },
             "textureWidth" : self.textureWidth,
             "textureHeight" : self.textureHeight,
             "textureSizeDDS" : self.textureSizeDDS,

--- a/Converter/Sequence_Metadata.py
+++ b/Converter/Sequence_Metadata.py
@@ -36,7 +36,8 @@ class MetaData():
     metaDataLock = Lock()
 
     def get_as_dict(self):
-        boundsCenter, boundsSize = self._get_metadata_bounds()
+        
+        boundsCenter, boundsSize = self.get_metadata_bounds()
 
         asDict = {
             "geometryType" : int(self.geometryType),
@@ -90,7 +91,7 @@ class MetaData():
 
         self.metaDataLock.release()
 
-    def update_metadata_maxbounds(self, newBoundsMin, newBoundsMax):
+    def extend_bounds(self, newBoundsMin, newBoundsMax):
 
         self.metaDataLock.acquire()
 
@@ -106,32 +107,23 @@ class MetaData():
         ]
 
         self.metaDataLock.release()
-
-    def get_metadata_bounds(self):
-        
-        self.metaDataLock.acquire()
-
-        boundsCenter, boundsSize = self._get_metadata_bounds()
-
-        self.metaDataLock.release()
-
-        return boundsCenter, boundsSize
     
-    def _get_metadata_bounds(self):
+    def get_metadata_bounds(self):
 
         boundsCenter = [
             (self.boundsMax[0] + self.boundsMin[0]) / 2,
             (self.boundsMax[1] + self.boundsMin[1]) / 2,
             (self.boundsMax[2] + self.boundsMin[2]) / 2,
         ]
-        # Flip bounds x axis, as we also flip the model's x axis to match Unity's coordinate system
-        boundsCenter[0] *= -1
 
         boundsSize = [
             self.boundsMax[0] - self.boundsMin[0],
             self.boundsMax[1] - self.boundsMin[1],
             self.boundsMax[2] - self.boundsMin[2],
         ]
+
+        # Flip bounds x axis, as we also flip the model's x axis to match Unity's coordinate system
+        boundsCenter[0] *= -1
 
         return boundsCenter, boundsSize
 

--- a/Converter/Sequence_Metadata.py
+++ b/Converter/Sequence_Metadata.py
@@ -19,8 +19,7 @@ class MetaData():
     ASTC = False
     hasUVs = False
     hasNormals = False
-    hasAlpha = True
-    halfPrecision = False
+    useCompression = False
     maxVertexCount = 0
     maxIndiceCount = 0
     boundsCenter = [0,0,0]
@@ -45,8 +44,7 @@ class MetaData():
             "ASTC" : self.ASTC,
             "hasUVs" : self.hasUVs,
             "hasNormals" : self.hasNormals,
-            "hasAlpha" : self.hasAlpha,
-            "halfPrecision": self.halfPrecision,
+            "useCompression" : self.useCompression,
             "maxVertexCount": self.maxVertexCount,
             "maxIndiceCount" : self.maxIndiceCount,
             "boundsCenter" : { # Export bounds as dicts for easier JSON parsing to Vector3 in Unity
@@ -70,15 +68,14 @@ class MetaData():
 
         return asDict
 
-    def set_metadata_Model(self, vertexCount, indiceCount, headerSize, geometryType, hasUV, hasNormals, hasAlpha, halfPrecision, listIndex):
+    def set_metadata_Model(self, vertexCount, indiceCount, headerSize, geometryType, hasUV, hasNormals, useCompressions, listIndex):
 
         self.metaDataLock.acquire()
 
         self.geometryType = geometryType
         self.hasUVs = hasUV
         self.hasNormals = hasNormals
-        self.hasAlpha = hasAlpha
-        self.halfPrecision = halfPrecision
+        self.useCompression = useCompressions
 
         if(vertexCount > self.maxVertexCount):
             self.maxVertexCount = vertexCount
@@ -130,7 +127,7 @@ class MetaData():
     def write_metaData(self, outputDir):
 
         self.metaDataLock.acquire()
-        if (not self.halfPrecision): # we already did that during the prepass
+        if (not self.useCompression): # we already did that during the prepass
             # Flip bounds x axis, as we also flip the model's x axis to match Unity's coordinate system
             self.boundsCenter[0] *= -1 # Min X
             self.boundsCenter = [x / len(self.headerSizes) for x in self.boundsCenter] # Average the center over the number of frames/models


### PR DESCRIPTION
The 'Use Compression' option has been added to the Pointcloud settings.
This basic compression works by omitting the alpha channel, since the value is always 0 anyway, and by using half-precision floats for the coordinates after they have been converted to the range [-1, 1] relative to the bounds. 
As floats are most accurate when close to 0, this shouldn't result in a significant loss of precision for smaller scenes. I didn't notice any difference in my sample scene.